### PR TITLE
Support Windows (currently this library doesn't work on Windows)

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@
 
     Parser.prototype.parse = function (tsv) {
         var sep   = this.sep
-          , lines = tsv.split(/[\n\r]/).filter(comments)
+          , lines = tsv.split(/(\r\n|[\r\n])/).filter(comments)
           , head  = !!this.header
           , keys  = head ? getValues(lines.shift(), sep) : {}
 


### PR DESCRIPTION
Split lines with this modifications handles new lines on Windows.
Before the split was splitting 2 times: 1 for /r and 1 for \n, adding an empty row for each row in the tsv.

\r = CR (Carriage Return) → Used as a new line character in Mac OS before X
\n = LF (Line Feed) → Used as a new line character in Unix/Mac OS X
\r\n = CR + LF → Used as a new line character in Windows